### PR TITLE
laravel 4.2; guzzle 4 & 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.1",
-        "illuminate/support": "^5.1"
+        "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
+        "illuminate/support": "~4.0|~5.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",

--- a/src/Http/PipedriveClient.php
+++ b/src/Http/PipedriveClient.php
@@ -3,17 +3,23 @@
 namespace Devio\Pipedrive\Http;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Post\PostFile;
+// use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Message\Request as GuzzleRequest;
 use GuzzleHttp\Exception\BadResponseException;
+use Psr\Http\Message\RequestInterface;
 
 class PipedriveClient implements Client
 {
     /**
      * The Guzzle client instance.
      *
-     * @var Client
+     * @var GuzzleClient
      */
     protected $client;
+
+    protected $queryDefaults = [];
 
     /**
      * GuzzleClient constructor.
@@ -21,13 +27,13 @@ class PipedriveClient implements Client
      * @param $url
      * @param $token
      */
-    public function __construct($url, $token)
+    public function __construct($token, $url)
     {
         $this->client = new GuzzleClient(
             [
-                'base_uri' => $url,
-                'query' => [
-                    'api_token' => $token
+                'base_url' => $url,
+                'defaults' => [
+                    'query'   => ['api_token' => $token],
                 ]
             ]
         );
@@ -42,14 +48,9 @@ class PipedriveClient implements Client
      */
     public function get($url, $parameters = [])
     {
-        $options = $this->getClient()
-            ->getConfig();
-        array_set($options, 'query', array_merge($parameters, $options['query']));
+        $request = $this->getClient()->createRequest('GET', $url, ['query' => $parameters]);
 
-        // For this particular case we have to include the parameters into the
-        // URL query. Merging the request default query configuration to the
-        // request parameters will make the query key contain everything.
-        return $this->execute(new GuzzleRequest('GET', $url), $options);
+        return $this->execute($request);
     }
 
     /**
@@ -61,18 +62,17 @@ class PipedriveClient implements Client
      */
     public function post($url, $parameters = [])
     {
-        $request = new GuzzleRequest('POST', $url);
-        $form = 'form_params';
-
+        return;
         // If any file key is found, we will assume we have to convert the data
         // into the multipart array structure. Otherwise, we will perform the
         // request as usual using the form_params with the given parameters.
         if (isset($parameters['file'])) {
-            $form = 'multipart';
             $parameters = $this->multipart($parameters);
         }
 
-        return $this->execute($request, [$form => $parameters]);
+        $request = $this->getClient()->createRequest('POST', $url, ['body' => $parameters]);
+
+        return $this->execute($request);
     }
 
     /**
@@ -87,18 +87,9 @@ class PipedriveClient implements Client
             throw new \InvalidArgumentException('File must be an instance of \SplFileInfo.');
         }
 
-        $result = [];
-        $content = file_get_contents($file->getPathname());
+        $parameters['file'] = new PostFile('file', file_get_contents($file->getPathname()), $file->getFilename());
 
-        foreach (array_except($parameters, 'file') as $key => $value) {
-            $result[] = ['name' => $key, 'contents' => (string) $value];
-        }
-        // Will convert every element of the array into a format accepted by the
-        // multipart encoding standards. It will also add a special item which
-        // includes the file key name, the content of the file and its name.
-        $result[] = ['name' => 'file', 'contents' => $content, 'filename' => $file->getFilename()];
-
-        return $result;
+        return $parameters;
     }
 
     /**
@@ -110,9 +101,10 @@ class PipedriveClient implements Client
      */
     public function put($url, $parameters = [])
     {
-        $request = new GuzzleRequest('PUT', $url);
+        return;
+        $request = $this->getClient()->createRequest('PUT', $url, ['body' => $parameters]);
 
-        return $this->execute($request, ['form_params' => $parameters]);
+        return $this->execute($request);
     }
 
     /**
@@ -124,20 +116,20 @@ class PipedriveClient implements Client
      */
     public function delete($url, $parameters = [])
     {
-        $request = new GuzzleRequest('DELETE', $url);
+        return;
+        $request = $this->getClient()->createRequest('DELETE', $url, ['body' => $parameters]);
 
-        return $this->execute($request, ['form_params' => $parameters]);
+        return $this->execute($request);
     }
 
     /**
      * Execute the request and returns the Response object.
      *
      * @param GuzzleRequest $request
-     * @param array $options
      * @param null $client
      * @return Response
      */
-    protected function execute(GuzzleRequest $request, array $options = [], $client = null)
+    protected function execute(GuzzleRequest $request, $client = null)
     {
         $client = $client ?: $this->getClient();
 
@@ -145,7 +137,7 @@ class PipedriveClient implements Client
         // and with the passed options wich may contain the query, body vars, or
         // any other info. Both OK and fail will generate a response object.
         try {
-            $response = $client->send($request, $options);
+            $response = $client->send($request);
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         }
@@ -162,7 +154,7 @@ class PipedriveClient implements Client
     /**
      * Return the client.
      *
-     * @return Client
+     * @return GuzzleClient
      */
     public function getClient()
     {

--- a/src/Http/PipedriveClient4.php
+++ b/src/Http/PipedriveClient4.php
@@ -62,7 +62,6 @@ class PipedriveClient4 implements Client
      */
     public function post($url, $parameters = [])
     {
-        return;
         // If any file key is found, we will assume we have to convert the data
         // into the multipart array structure. Otherwise, we will perform the
         // request as usual using the form_params with the given parameters.
@@ -101,7 +100,6 @@ class PipedriveClient4 implements Client
      */
     public function put($url, $parameters = [])
     {
-        return;
         $request = $this->getClient()->createRequest('PUT', $url, ['body' => $parameters]);
 
         return $this->execute($request);
@@ -116,7 +114,6 @@ class PipedriveClient4 implements Client
      */
     public function delete($url, $parameters = [])
     {
-        return;
         $request = $this->getClient()->createRequest('DELETE', $url, ['body' => $parameters]);
 
         return $this->execute($request);

--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -2,6 +2,7 @@
 
 namespace Devio\Pipedrive;
 
+use Devio\Pipedrive\Http\PipedriveClient4;
 use Illuminate\Support\Str;
 use Devio\Pipedrive\Http\Request;
 use Devio\Pipedrive\Http\PipedriveClient;
@@ -23,14 +24,22 @@ class Pipedrive
     protected $token;
 
     /**
+     * The guzzle version
+     *
+     * @var int
+     */
+    protected $guzzleVersion;
+
+    /**
      * Pipedrive constructor.
      *
      * @param $token
      */
-    public function __construct($token = '', $uri = 'https://api.pipedrive.com/v1/')
+    public function __construct($token = '', $uri = 'https://api.pipedrive.com/v1/', $guzzleVersion = 6)
     {
         $this->token = $token;
         $this->baseURI = $uri;
+        $this->guzzleVersion = $guzzleVersion;
     }
 
     /**
@@ -74,7 +83,11 @@ class Pipedrive
      */
     protected function getClient()
     {
-        return new PipedriveClient($this->token, $this->getBaseURI());
+        if ($this->guzzleVersion >= 6) {
+            return new PipedriveClient($this->getBaseURI(), $this->token);
+        } else {
+            return new PipedriveClient4($this->getBaseURI(), $this->token);
+        }
     }
 
     /**

--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -13,7 +13,7 @@ class Pipedrive
      *
      * @var string
      */
-    protected $baseURI = 'https://api.pipedrive.com/v1/';
+    protected $baseURI;
 
     /**
      * The API token.
@@ -27,9 +27,10 @@ class Pipedrive
      *
      * @param $token
      */
-    public function __construct($token = '')
+    public function __construct($token = '', $uri = 'https://api.pipedrive.com/v1/')
     {
         $this->token = $token;
+        $this->baseURI = $uri;
     }
 
     /**

--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -74,7 +74,7 @@ class Pipedrive
      */
     protected function getClient()
     {
-        return new PipedriveClient($this->getBaseURI(), $this->token);
+        return new PipedriveClient($this->token, $this->getBaseURI());
     }
 
     /**

--- a/src/PipedriveServiceProvider.php
+++ b/src/PipedriveServiceProvider.php
@@ -22,12 +22,13 @@ class PipedriveServiceProvider extends ServiceProvider
         $this->app->singleton(Pipedrive::class, function ($app) {
             $token = $app['config']->get('services.pipedrive.token');
             $uri = $app['config']->get('services.pipedrive.uri') ?: 'https://api.pipedrive.com/v1/';
+            $guzzleVersion = $app['config']->get('services.pipedrive.guzzle_version') ?: 6;
 
             if (! $token) {
                 throw new PipedriveException('Pipedrive was not configured in services.php configuration file.');
             }
 
-            return new Pipedrive($token, $uri);
+            return new Pipedrive($token, $uri, $guzzleVersion);
         });
 
         $this->app->alias(Pipedrive::class, 'pipedrive');

--- a/src/PipedriveServiceProvider.php
+++ b/src/PipedriveServiceProvider.php
@@ -14,14 +14,20 @@ class PipedriveServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->booting( function () {
+            $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+            $loader->alias( 'Pipedrive', 'Devio\Pipedrive\PipedriveFacade' );
+        } );
+
         $this->app->singleton(Pipedrive::class, function ($app) {
             $token = $app['config']->get('services.pipedrive.token');
+            $uri = $app['config']->get('services.pipedrive.uri') ?: 'https://api.pipedrive.com/v1/';
 
             if (! $token) {
                 throw new PipedriveException('Pipedrive was not configured in services.php configuration file.');
             }
 
-            return new Pipedrive($token);
+            return new Pipedrive($token, $uri);
         });
 
         $this->app->alias(Pipedrive::class, 'pipedrive');


### PR DESCRIPTION
Hi! I have implemented version that works with guzzle 4 & 5 and laravel 4.2.  Also made api url parameter configurable.
It works like before by default, just 2 new optional config parameters added:
```php
'pipedrive' => [
	'token' => $_ENV['PIPEDRIVE_API_KEY'],
	'uri'   => $_ENV['PIPEDRIVE_API_URI'],
	'guzzle_version'   => 4,
]
```