### PR TITLE
Delete empty because logically equivalent

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -93,7 +93,7 @@ class Builder
     {
         $result = $this->getTarget();
 
-        if (! empty($this->getResource())) {
+        if (! $this->getResource()) {
             $result = $this->getResource() . '/' . $result;
         }
 


### PR DESCRIPTION
empty() needs to access the value by reference (in order to check whether that reference points to something that exists), and PHP before 5.5 didn't support references to temporary values returned from functions.

Empty is just an alias for !isset($thing) || !$thing. When the thing you're checking always exists (in PHP results of function calls always exist), the empty() function is nothing but a negation operator.