### PR TITLE
Add require for minimum php 5.5 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": ">=5.5.0",
         "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
         "illuminate/support": "~4.0|~5.0"
     },


### PR DESCRIPTION
specify minimum required php version, because of use of `[]`