### PR TITLE
Fix for mailMessages endpoints

### DIFF
--- a/src/Resources/Basics/Entity.php
+++ b/src/Resources/Basics/Entity.php
@@ -29,7 +29,7 @@ abstract class Entity extends Resource
     {
         array_set($options, 'id', $id);
 
-        return $this->request->get(':id/emailMessages', $options);
+        return $this->request->get(':id/mailMessages', $options);
     }
 
     /**


### PR DESCRIPTION
According to the current Pipedrive API documentation, the endpoint URL to retrieve mailMessages associated with an object ends in `/mailMessages`, not `/emailMessages`.

* https://developers.pipedrive.com/docs/api/v1/#!/Deals/get_deals_id_mailMessages
* https://developers.pipedrive.com/docs/api/v1/#!/Organizations/get_organizations_id_mailMessages
* https://developers.pipedrive.com/docs/api/v1/#!/Persons/get_persons_id_mailMessages