### PR TITLE
OAuth support for (Guzzle >= 6)

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -34,6 +34,23 @@ class Builder
      */
     protected $token;
 
+    protected $isOauth = false;
+
+    public function isOauth()
+    {
+        return $this->isOauth;
+    }
+
+    public static function OAuth()
+    {
+        $new = new self();
+
+        $new->base = 'https://api-proxy.pipedrive.com/{endpoint}';
+        $new->isOauth = true;
+
+        return $new;
+    }
+
     /**
      * Get the name of the URI parameters.
      *
@@ -93,7 +110,7 @@ class Builder
     {
         $result = $this->getTarget();
 
-        if (! empty($this->getResource())) {
+        if (!empty($this->getResource())) {
             $result = $this->getResource() . '/' . $result;
         }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -39,4 +39,6 @@ interface Client
      * @return Response
      */
     public function delete($url, $parameters = []);
+
+    public function isOauth();
 }

--- a/src/Http/PipedriveClient4.php
+++ b/src/Http/PipedriveClient4.php
@@ -21,6 +21,13 @@ class PipedriveClient4 implements Client
 
     protected $queryDefaults = [];
 
+    protected $isOauth = false;
+
+    public function isOauth()
+    {
+        return $this->isOauth;
+    }
+
     /**
      * GuzzleClient constructor.
      *

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -23,7 +23,7 @@ class Request
     public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->builder = $this->client->isOauth() ? new Builder() : Builder::OAuth();
+        $this->builder = $this->client->isOauth() ? Builder::OAuth() : new Builder();
     }
 
     /**

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -23,7 +23,7 @@ class Request
     public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->builder = new Builder();
+        $this->builder = $this->client->isOauth() ? new Builder() : Builder::OAuth();
     }
 
     /**
@@ -77,7 +77,7 @@ class Request
         // If the request did not succeed, we will notify the user via Exception
         // and include the server error if found. If it is OK and also server
         // inludes the success variable, we will return the response data.
-        if (! isset($content) || !($response->getStatusCode() == 302 || $response->isSuccess() )) {
+        if (!isset($content) || !($response->getStatusCode() == 302 || $response->isSuccess())) {
             if ($response->getStatusCode() == 404) {
                 throw new ItemNotFoundException($content->error);
             }
@@ -120,7 +120,7 @@ class Request
     public function __call($name, $args = [])
     {
         if (in_array($name, ['get', 'post', 'put', 'delete'])) {
-            $options = ! empty($args[1]) ? $args[1] : [];
+            $options = !empty($args[1]) ? $args[1] : [];
 
             // Will pass the function name as the request type. The second argument
             // is the URI passed to the method. The third parameter will include

--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 use Devio\Pipedrive\Http\Request;
 use Devio\Pipedrive\Http\PipedriveClient;
 
+use GuzzleHttp\Client as GuzzleClient;
+
 class Pipedrive
 {
     /**
@@ -30,6 +32,19 @@ class Pipedrive
      */
     protected $guzzleVersion;
 
+    protected $isOauth;
+
+    protected $clientId;
+    protected $clientSecret;
+    protected $redirectUrl;
+
+    protected $storage;
+
+    public function isOauth()
+    {
+        return $this->isOauth;
+    }
+
     /**
      * Pipedrive constructor.
      *
@@ -40,6 +55,85 @@ class Pipedrive
         $this->token = $token;
         $this->baseURI = $uri;
         $this->guzzleVersion = $guzzleVersion;
+
+        $this->isOauth = false;
+    }
+
+    public static function OAuth($config)
+    {
+        $guzzleVersion = isset($config['guzzleVersion']) ? $config['guzzleVersion'] : 6;
+
+        $new = new self('oauth', 'https://api-proxy.pipedrive.com/', $guzzleVersion);
+
+        $new->isOauth = true;
+
+        $new->clientId = $config['clientId'];
+        $new->clientSecret = $config['clientSecret'];
+        $new->redirectUrl = $config['redirectUrl'];
+
+        $new->storage = $config['storage'];
+
+        return $new;
+    }
+
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+
+    public function getClientSecret()
+    {
+        return $this->clientSecret;
+    }
+
+    public function getRedirectUrl()
+    {
+        return $this->redirectUrl;
+    }
+
+    public function getStorage()
+    {
+        return $this->storage;
+    }
+
+    public function OAuthRedirect()
+    {
+        $params = [
+            'client_id' => $this->clientId,
+            'state' => '',
+            'redirect_uri' => $this->redirectUrl,
+        ];
+        $query = http_build_query($params);
+        $url = 'https://oauth.pipedrive.com/oauth/authorize?' . $query;
+        header('Location: ' . $url);
+        exit;
+    }
+
+    public function authorize($code)
+    {
+        $client = new GuzzleClient([
+            'auth' => [
+                $this->getClientId(),
+                $this->getClientSecret()
+            ]
+        ]);
+        $response = $client->request('POST', 'https://oauth.pipedrive.com/oauth/token', [
+            'form_params' => [
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => $this->redirectUrl,
+            ]
+        ]);
+        $resBody = json_decode($response->getBody());
+
+        $token = new PipedriveToken([
+            'access_token' => $resBody->access_token,
+            'expires_at' => time() + $resBody->expires_in,
+            'refresh_token' => $resBody->refresh_token,
+        ]);
+
+        $this->storage->setToken($token);
     }
 
     /**
@@ -84,7 +178,7 @@ class Pipedrive
     protected function getClient()
     {
         if ($this->guzzleVersion >= 6) {
-            return new PipedriveClient($this->getBaseURI(), $this->token);
+            return $this->isOauth() ? PipedriveClient::OAuth($this->getBaseURI(), $this->storage, $this) : new PipedriveClient($this->getBaseURI(), $this->token);
         } else {
             return new PipedriveClient4($this->getBaseURI(), $this->token);
         }
@@ -140,7 +234,7 @@ class Pipedrive
      */
     public function __call($name, $arguments)
     {
-        if (! in_array($name, get_class_methods(get_class()))) {
+        if (!in_array($name, get_class_methods(get_class()))) {
             return $this->{$name};
         }
     }

--- a/src/PipedriveToken.php
+++ b/src/PipedriveToken.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Devio\Pipedrive;
+
+use GuzzleHttp\Client as GuzzleClient;
+
+class PipedriveToken
+{
+    protected $access_token;
+    protected $expires_at;
+    protected $refresh_token;
+
+    public function __construct($config)
+    {
+        $assign = ['access_token', 'expires_at', 'refresh_token'];
+        foreach ($assign as $a) {
+            $this->{$a} = !empty($config[$a]) ? $config[$a] : null;
+        }
+    }
+
+    public function access_token()
+    {
+        return $this->access_token;
+    }
+
+    public function expires_at()
+    {
+        return $this->expires_at;
+    }
+
+    public function refresh_token()
+    {
+        return $this->refresh_token;
+    }
+
+    public function valid()
+    {
+        return !empty($this->access_token);
+    }
+
+    public function refresh_if_needed($pipedrive)
+    {
+        if ($this->needs_refresh()) {
+            $client = new GuzzleClient([
+                'auth' => [
+                    $pipedrive->getClientId(),
+                    $pipedrive->getClientSecret()
+                ]
+            ]);
+            $response = $client->request('POST', 'https://oauth.pipedrive.com/oauth/token', [
+                'form_params' => [
+                    'grant_type' => 'refresh_token',
+                    'refresh_token' => $this->refresh_token
+                ]
+            ]);
+            $new_token = json_decode($response->getBody());
+
+            $this->access_token = $new_token->access_token;
+            $this->expires_at = time() + $new_token->expires_in;
+            $this->refresh_token = $new_token->refresh_token;
+
+            $storage = $pipedrive->getStorage();
+
+            $storage->setToken($this);
+        }
+    }
+
+    public function needs_refresh()
+    {
+        return (int)$this->expires_at - time() < 1;
+    }
+}

--- a/src/PipedriveTokenStorage.php
+++ b/src/PipedriveTokenStorage.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Devio\Pipedrive;
+
+use Devio\Pipedrive\PipedriveToken;
+
+interface PipedriveTokenStorage
+{
+    public function setToken(PipedriveToken $token);
+
+    public function getToken();
+}


### PR DESCRIPTION
Fixed previous PR.

Pipedrive OAuth can be instantiated like this
```php
$pipedrive = Pipedrive::OAuth([
    'clientId' => 'xxxxx',
    'clientSecret' => 'xxxxx',
    'redirectUrl' => 'xxxxx',
    'storageClass' => new PipedriveTokenIO()
]);
```
`PipedriveTokenIO` is the user's own implementation of the `PipedriveTokenStorage` interface, with the two `setToken` and `getToken` methods.

`setToken` accepts an instance of `PipedriveToken`, which has these attributes
```php
protected $access_token;
protected $expires_at; // expires AT, not IN (calculated as time() + expires_in, coming from Pipedrive
protected $refresh_token;
```
`PipedriveToken` **silently takes care of refreshing the token when needed**, and updates it through the `setToken` method.

`PipedriveClient` checks if the token is valid. If it's not (or it's not set yet), it calls `$pipedrive->OAuthRedirect();`. On the callback page, you can call `$pipedrive->authorize($_GET['code']);` to get the first token (also automatically stored through the `setToken` method).

TODO: 
- comments
- support for Guzzle < 6 (which should be quick to implement)
- better handling of the redirect (?)

Here's a basic, not-so-great implementation of PipedriveTokenStorage, just to get the idea:
```php
class PipedriveTokenIO implements \Devio\Pipedrive\PipedriveTokenStorage
{
    public function setToken(\Devio\Pipedrive\PipedriveToken $token)
    {
        $_SESSION['token'] = serialize($token); // or encrypt and store in the db, or anything else...
    }

    public function getToken()
    {
        return isset($_SESSION['token']) ? unserialize($_SESSION['token']) : null;
    }
}
```