### PR TITLE
Adds the ActivityFields resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Every Resource logic is located at the `src/Resources` directory. However we'll 
 | Resource                  | Methods implemented       | Notes         |
 |:--------------------------|:--------------------------|:--------------|
 | Activities                | :white_check_mark: 6/6    | |
+| ActivityFields            | :white_check_mark: 1/1    | |
 | ActivityTypes             | :white_check_mark: 5/5    | |
 | Currencies                | :white_check_mark: 1/1    | |
 | DealFields                | :white_check_mark: 25/25  | |

--- a/src/Resources/ActivityFields.php
+++ b/src/Resources/ActivityFields.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Devio\Pipedrive\Resources;
+
+use Devio\Pipedrive\Resources\Basics\Resource;
+
+class ActivityFields extends Resource
+{
+}


### PR DESCRIPTION
Adds the missing [ActivityFields](https://developers.pipedrive.com/docs/api/v1/#!/ActivityFields) resources and update the table of resources in the README.md