### PR TITLE
extending pipedrive exception with more contents from api

### DIFF
--- a/src/Exceptions/PipedriveException.php
+++ b/src/Exceptions/PipedriveException.php
@@ -2,6 +2,51 @@
 
 namespace Devio\Pipedrive\Exceptions;
 
+use Throwable;
+
 class PipedriveException extends \Exception
 {
+    protected $error_info = '';
+    protected $data;
+    protected $additional_data;
+    protected $success;
+
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        Throwable $previous = null,
+        ?string $error_info = '',
+        $additional_data = null,
+        $data = null,
+        bool $success = false
+    )
+    {
+        parent::__construct($message, $code, $previous);
+        $this->error_info = $error_info;
+        $this->additional_data = $additional_data;
+        $this->data = $data;
+        $this->success = $success;
+    }
+
+    public function getErrorInfo(): ?string
+    {
+        return $this->error_info;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function getAdditionalData()
+    {
+        return $this->additional_data;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -89,7 +89,13 @@ class Request
             }
 
             throw new PipedriveException(
-                isset($content->error) ? $content->error : "Error unknown."
+                isset($content->error) ? $content->error : "Error unknown.",
+                (int)$response->getStatusCode(),
+                null,
+                isset($content->error_info) ? $content->error_info : "Error info not provided",
+                isset($content->additional_data) ? $content->additional_data : "Additional data not provided",
+                isset($content->data) ? $content->data : "Data not provided",
+                isset($content->success) ? (bool)$content->success : false
             );
         }
 


### PR DESCRIPTION
The pipedrive API delivers much more information when an exception occurs. I would like to retrieve this information and not only the error message.