### PR TITLE
Change api-proxy.pipedrive.com to api.pipedrive.com

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -103,7 +103,7 @@ class Builder
     {
         $instance = new self();
 
-        $instance->base = 'https://api-proxy.pipedrive.com/{endpoint}';
+        $instance->base = 'https://api.pipedrive.com/{endpoint}';
         $instance->isOauth = true;
 
         return $instance;

--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -158,7 +158,7 @@ class Pipedrive
     {
         $guzzleVersion = isset($config['guzzleVersion']) ? $config['guzzleVersion'] : 6;
 
-        $new = new self('oauth', 'https://api-proxy.pipedrive.com/', $guzzleVersion);
+        $new = new self('oauth', 'https://api.pipedrive.com/', $guzzleVersion);
 
         $new->isOauth = true;
 


### PR DESCRIPTION
Latest Pipedrive's update unified the domains for api calls for API token and OAuth token.