### PR TITLE
Allow for installation next to Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
-        "illuminate/support": "~4.0|~5.0",
+        "illuminate/support": "~4.0|~5.0|~6.0",
         "laravel/helpers": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
As far as I could tell no changes are actually needed since only some helpers are used. There don't seem to be any changes in them.

> https://laravel.com/docs/6.0/upgrade

Would be appreciated if you could take a look at this and tag a release so this package can be used on a Laravel 6 installation.