### PR TITLE
Mailbox class added to resource

### DIFF
--- a/src/Resources/Mailbox.php
+++ b/src/Resources/Mailbox.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Devio\Pipedrive\Resources;
+
+use Devio\Pipedrive\Http\Response;
+use Devio\Pipedrive\Resources\Basics\Resource;
+
+class Mailbox extends Resource
+{
+    /**
+     * Get the Mail threads details by ID.
+     *
+     * @param $id   Mail threads ID to find.
+	 * @return Response
+     */
+    public function find($id)
+    {
+        return $this->request->get('mailThreads/:id', compact('id'));
+    }
+
+    /**
+     * Get list of mail threads
+     *
+     * @param       $folder
+     * @param array $options
+	 * @return Response 
+     */
+    public function mailThreads($folder, $options = [])
+    {
+        $options['folder'] = $folder;
+
+        return $this->request->get('mailThreads', $options);
+    }
+}


### PR DESCRIPTION
I have implemented this class to fetch mailThreads from PipeDrive API. The resource was not already present in the API client.

The following end-points  has been implemented.

1. GET https://api.pipedrive.com/v1/mailbox/mailThreads?folder=inbox&start=0&limit=2&api_token=??
2. GET https://api.pipedrive.com/v1/mailbox/mailThreads/122?api_token=
