### PR TITLE
Improve doc for find method

### DIFF
--- a/src/Resources/Basics/Resource.php
+++ b/src/Resources/Basics/Resource.php
@@ -56,7 +56,7 @@ abstract class Resource
     /**
      * Get the entity details by ID.
      *
-     * @param $id   Entity ID to find.
+     * @param int $id Entity ID to find.
 	 * @return Response
      */
     public function find($id)


### PR DESCRIPTION
My IDE is complaining about the argument because it
thought that the argument `$id` should be of type
`Entity`, which is obviously unintended.
I added the type to the arguments docs.