### PR TITLE
Enable Laravel package discover

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,15 @@
         "psr-4": {
             "Devio\\Pipedrive\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Devio\\Pipedrive\\PipedriveServiceProvider"
+            ],
+            "aliases": {
+                "Pipedrive": "Devio\\Pipedrive\\PipedriveFacade"
+            }
+        }
     }
 }


### PR DESCRIPTION
Laravel has supported Package Discovery since Laravel 5.5 (give or take). This means that we can register the facade and provider automatically by including it in `composer.json`.