### PR TITLE
Add leads to Pipedrive and facade, add property hints

### DIFF
--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -16,6 +16,7 @@ use Devio\Pipedrive\Resources\Files;
 use Devio\Pipedrive\Resources\Filters;
 use Devio\Pipedrive\Resources\GlobalMessages;
 use Devio\Pipedrive\Resources\Goals;
+use Devio\Pipedrive\Resources\Leads;
 use Devio\Pipedrive\Resources\NoteFields;
 use Devio\Pipedrive\Resources\Notes;
 use Devio\Pipedrive\Resources\OrganizationFields;
@@ -55,6 +56,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * @method Filters filters()
  * @method GlobalMessages globalMessages()
  * @method Goals goals()
+ * @method Leads leads()
  * @method NoteFields noteFields()
  * @method Notes notes()
  * @method OrganizationFields organizationFields()
@@ -75,6 +77,40 @@ use GuzzleHttp\Client as GuzzleClient;
  * @method Users users()
  * @method UserSettings userSettings()
  * @method Webhooks webhooks()
+ * @property-read Activities $activities
+ * @property-read ActivityFields $activityFields
+ * @property-read ActivityTypes $activityTypes
+ * @property-read Authorizations $authorizations
+ * @property-read Currencies $currencies
+ * @property-read DealFields $dealFields
+ * @property-read Deals $deals
+ * @property-read EmailMessages $emailMessages
+ * @property-read EmailThreads $emailThreads
+ * @property-read Files $files
+ * @property-read Filters $filters
+ * @property-read GlobalMessages $globalMessages
+ * @property-read Goals $goals
+ * @property-read Leads $leads
+ * @property-read NoteFields $noteFields
+ * @property-read Notes $notes
+ * @property-read OrganizationFields $organizationFields
+ * @property-read OrganizationRelationships $organizationRelationships
+ * @property-read Organizations $organizations
+ * @property-read PermissionSets $permissionSets
+ * @property-read PersonFields $personFields
+ * @property-read Persons $persons
+ * @property-read Pipelines $pipelines
+ * @property-read ProductFields $productFields
+ * @property-read Products $products
+ * @property-read PushNotifications $pushNotifications
+ * @property-read Recents $recents
+ * @property-read Roles $roles
+ * @property-read SearchResults $searchResults
+ * @property-read Stages $stages
+ * @property-read UserConnections $userConnections
+ * @property-read Users $users
+ * @property-read UserSettings $userSettings
+ * @property-read Webhooks $webhooks
  */
 class Pipedrive
 {

--- a/src/PipedriveFacade.php
+++ b/src/PipedriveFacade.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static Resources\Filters filters()
  * @method static Resources\GlobalMessages globalMessages()
  * @method static Resources\Goals goals()
+ * @method static Resources\Leads leads()
  * @method static Resources\NoteFields noteFields()
  * @method static Resources\Notes notes()
  * @method static Resources\OrganizationFields organizationFields()
@@ -37,6 +38,40 @@ use Illuminate\Support\Facades\Facade;
  * @method static Resources\UserConnections userConnections()
  * @method static Resources\Users users()
  * @method static Resources\UserSettings userSettings()
+ * @property-read Resources\Activities $activities
+ * @property-read Resources\ActivityFields $activityFields
+ * @property-read Resources\ActivityTypes $activityTypes
+ * @property-read Resources\Authorizations $authorizations
+ * @property-read Resources\Currencies $currencies
+ * @property-read Resources\DealFields $dealFields
+ * @property-read Resources\Deals $deals
+ * @property-read Resources\EmailMessages $emailMessages
+ * @property-read Resources\EmailThreads $emailThreads
+ * @property-read Resources\Files $files
+ * @property-read Resources\Filters $filters
+ * @property-read Resources\GlobalMessages $globalMessages
+ * @property-read Resources\Goals $goals
+ * @property-read Resources\Leads $leads
+ * @property-read Resources\NoteFields $noteFields
+ * @property-read Resources\Notes $notes
+ * @property-read Resources\OrganizationFields $organizationFields
+ * @property-read Resources\OrganizationRelationships $organizationRelationships
+ * @property-read Resources\Organizations $organizations
+ * @property-read Resources\PermissionSets $permissionSets
+ * @property-read Resources\PersonFields $personFields
+ * @property-read Resources\Persons $persons
+ * @property-read Resources\Pipelines $pipelines
+ * @property-read Resources\ProductFields $productFields
+ * @property-read Resources\Products $products
+ * @property-read Resources\PushNotifications $pushNotifications
+ * @property-read Resources\Recents $recents
+ * @property-read Resources\Roles $roles
+ * @property-read Resources\SearchResults $searchResults
+ * @property-read Resources\Stages $stages
+ * @property-read Resources\UserConnections $userConnections
+ * @property-read Resources\Users $users
+ * @property-read Resources\UserSettings $userSettings
+ * @property-read Resources\Webhooks $webhooks
  */
 class PipedriveFacade extends Facade
 {


### PR DESCRIPTION
Happy that leads was added recently, but it was not typehinted so it wasn't quite as discoverable that it was implemented. :) Likewise, since `__get` magic is in place, too, I added `@property-read` hints as well so typehinting is available both for `$pipedrive->leads()` *and* `$pipedrive->leads` style of resolving the resource.