### PR TITLE
Add ItemSearches endpoint, deprecate SearchResults

### DIFF
--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -16,6 +16,7 @@ use Devio\Pipedrive\Resources\Files;
 use Devio\Pipedrive\Resources\Filters;
 use Devio\Pipedrive\Resources\GlobalMessages;
 use Devio\Pipedrive\Resources\Goals;
+use Devio\Pipedrive\Resources\ItemSearches;
 use Devio\Pipedrive\Resources\NoteFields;
 use Devio\Pipedrive\Resources\Notes;
 use Devio\Pipedrive\Resources\OrganizationFields;
@@ -55,6 +56,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * @method Filters filters()
  * @method GlobalMessages globalMessages()
  * @method Goals goals()
+ * @method ItemSearches itemSearches()
  * @method NoteFields noteFields()
  * @method Notes notes()
  * @method OrganizationFields organizationFields()

--- a/src/PipedriveFacade.php
+++ b/src/PipedriveFacade.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static Resources\Filters filters()
  * @method static Resources\GlobalMessages globalMessages()
  * @method static Resources\Goals goals()
+ * @method static Resources\ItemSearches itemSearches()
  * @method static Resources\NoteFields noteFields()
  * @method static Resources\Notes notes()
  * @method static Resources\OrganizationFields organizationFields()

--- a/src/Resources/ItemSearches.php
+++ b/src/Resources/ItemSearches.php
@@ -5,10 +5,7 @@ namespace Devio\Pipedrive\Resources;
 use Devio\Pipedrive\Http\Response;
 use Devio\Pipedrive\Resources\Basics\Resource;
 
-/**
- * @deprecated
- */
-class SearchResults extends Resource
+class ItemSearches extends Resource
 {
     /**
      * Enabled abstract methods.


### PR DESCRIPTION
We'll want to add the property to `Pipedrive.php` as well, but we can't just yet as it would conflict with #99. But, to be fair, it might already conflict with that PR so oh well. :)

```
 * @property-read ItemSearches $itemSearches
```

If you want to do it yourself, awesome. If you want me to do it after you merge the other PRs, just let me know!