### PR TITLE
Ensure Leads()->add() post as JSON

### DIFF
--- a/src/Http/PipedriveClient.php
+++ b/src/Http/PipedriveClient.php
@@ -5,6 +5,7 @@ namespace Devio\Pipedrive\Http;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\RequestOptions;
 
 class PipedriveClient implements Client
 {
@@ -107,6 +108,11 @@ class PipedriveClient implements Client
         if (isset($parameters['file'])) {
             $form = 'multipart';
             $parameters = $this->multipart($parameters);
+        }
+
+        if (isset($parameters['json'])) {
+            $form = RequestOptions::JSON;
+            $parameters = array_except($parameters, RequestOptions::JSON);
         }
 
         return $this->execute($request, [$form => $parameters]);

--- a/src/Resources/Basics/Resource.php
+++ b/src/Resources/Basics/Resource.php
@@ -31,6 +31,13 @@ abstract class Resource
     protected $disabled = [];
 
     /**
+     * Should requests to add POST as JSON?
+     *
+     * @var bool
+     */
+    protected $addPostedAsJson = false;
+
+    /**
      * Endpoint constructor.
      *
      * @param Request $request
@@ -72,6 +79,10 @@ abstract class Resource
      */
     public function add(array $values)
     {
+        if ($this->addPostedAsJson) {
+            $values['json'] = true;
+        }
+
         return $this->request->post('', $values);
     }
 

--- a/src/Resources/Leads.php
+++ b/src/Resources/Leads.php
@@ -14,6 +14,8 @@ class Leads extends Resource
      */
     protected $disabled = ['deleteBulk'];
 
+    protected $addPostedAsJson = true;
+
     /**
      * Get all labels.
      *


### PR DESCRIPTION
In order to POST to the /leads endpoint to add a new lead, we need to send it as JSON. Unsure which other endpoints might have this issue, too? I tried to do it in a way that was flexible and consistent with how some of the other parts of the code is handled but happy to refactor to make it easier/better/more consistent.