### PR TITLE
Fixed PipedriveException in handleResponse

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -89,7 +89,7 @@ class Request
             }
 
             throw new PipedriveException(
-                isset($content->error) ? $content->error : "Error unknown."
+                isset($content->error) ? $content->error->message : "Error unknown."
             );
         }
 


### PR DESCRIPTION
When a status code error other than 404 occurs, the `$content->error` is a stdClass. So, when you try to throw the exception PipedriveException it breaks with the message:

```
PHP Error:  Wrong parameters for Devio/Pipedrive/Exceptions/PipedriveException([string $message [, long $code [, Throwable $previous = NULL]]]) in /var/www/releases/1651/vendor/devio/pipedrive/src/Http/Request.php on line 92
```

You can reproduce this error by searching with an empty string:
```php
Pipedrive::organizations()->search('');
```

The expected result with the exception::
```
Devio\Pipedrive\Exceptions\PipedriveException: ServerError [ERR_INVALID_INPUT]: Invalid input: "term" is not allowed to be empty
```