### PR TITLE
Added callLogs resource

### DIFF
--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -7,6 +7,7 @@ use Devio\Pipedrive\Resources\Activities;
 use Devio\Pipedrive\Resources\ActivityFields;
 use Devio\Pipedrive\Resources\ActivityTypes;
 use Devio\Pipedrive\Resources\Authorizations;
+use Devio\Pipedrive\Resources\CallLogs;
 use Devio\Pipedrive\Resources\Currencies;
 use Devio\Pipedrive\Resources\DealFields;
 use Devio\Pipedrive\Resources\Deals;
@@ -48,6 +49,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * @method ActivityFields activityFields()
  * @method ActivityTypes activityTypes()
  * @method Authorizations authorizations()
+ * @method CallLogs callLogs()
  * @method Currencies currencies()
  * @method DealFields dealFields()
  * @method Deals deals()
@@ -83,6 +85,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * @property-read ActivityFields $activityFields
  * @property-read ActivityTypes $activityTypes
  * @property-read Authorizations $authorizations
+ * @property-read CallLogs $callLogs
  * @property-read Currencies $currencies
  * @property-read DealFields $dealFields
  * @property-read Deals $deals

--- a/src/PipedriveFacade.php
+++ b/src/PipedriveFacade.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static Resources\ActivityTypes activityTypes()
  * @method static Resources\Authorizations authorizations()
  * @method static Resources\Currencies currencies()
+ * @method static Resources\CallLogs callLogs()
  * @method static Resources\DealFields dealFields()
  * @method static Resources\Deals deals()
  * @method static Resources\EmailMessages emailMessages()
@@ -43,6 +44,7 @@ use Illuminate\Support\Facades\Facade;
  * @property-read Resources\ActivityFields $activityFields
  * @property-read Resources\ActivityTypes $activityTypes
  * @property-read Resources\Authorizations $authorizations
+ * @property-read Resources\CallLogs $callLogs
  * @property-read Resources\Currencies $currencies
  * @property-read Resources\DealFields $dealFields
  * @property-read Resources\Deals $deals

--- a/src/Resources/CallLogs.php
+++ b/src/Resources/CallLogs.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Devio\Pipedrive\Resources;
+
+use Devio\Pipedrive\Resources\Basics\Resource;
+
+class CallLogs extends Resource
+{
+    protected $enabled = ['all', 'find', 'add', 'delete', 'addRecording'];
+
+    
+    /**
+     * Upload a recording file (audio) to a callLog
+     *
+     * @param $id
+     * @param \SplFileInfo $file
+     * @return Response
+     */
+    public function addRecording($id, \SplFileInfo $file) {
+        return $this->request->post(':id/recordings', compact('id', 'file'));
+    }
+}


### PR DESCRIPTION
I needed to use this api calls but noticed there was no resource for it, you might want to also update the readme.
The callLogs resource works a bit different, since it must be linked to an activity, but you are able to create a CallLog and it will automatically create a wrapper activity for it. After creating a CallLog, you can add an audio file to it.