### PR TITLE
fix: use correct name ItemSearch in phpdoc

### DIFF
--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -17,7 +17,7 @@ use Devio\Pipedrive\Resources\Files;
 use Devio\Pipedrive\Resources\Filters;
 use Devio\Pipedrive\Resources\GlobalMessages;
 use Devio\Pipedrive\Resources\Goals;
-use Devio\Pipedrive\Resources\ItemSearches;
+use Devio\Pipedrive\Resources\ItemSearch;
 use Devio\Pipedrive\Resources\Leads;
 use Devio\Pipedrive\Resources\NoteFields;
 use Devio\Pipedrive\Resources\Notes;
@@ -59,7 +59,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * @method Filters filters()
  * @method GlobalMessages globalMessages()
  * @method Goals goals()
- * @method ItemSearches itemSearches()
+ * @method ItemSearch itemSearch()
  * @method Leads leads()
  * @method NoteFields noteFields()
  * @method Notes notes()
@@ -95,7 +95,7 @@ use GuzzleHttp\Client as GuzzleClient;
  * @property-read Filters $filters
  * @property-read GlobalMessages $globalMessages
  * @property-read Goals $goals
- * @property-read ItemSearches $itemSearches
+ * @property-read ItemSearch $itemSearch
  * @property-read Leads $leads
  * @property-read NoteFields $noteFields
  * @property-read Notes $notes


### PR DESCRIPTION
the ItemSearches class got renamed into ItemSearch but the phpdoc is still referencing the old name.

This fixes it by using the new name.