### PR TITLE
introduce ability to set response limit

### DIFF
--- a/src/Http/PipedriveClient.php
+++ b/src/Http/PipedriveClient.php
@@ -31,7 +31,7 @@ class PipedriveClient implements Client
      */
     public function __construct($url, $credentials)
     {
-        list($headers, $query) = [[], []];
+        list($headers, $query) = [[], ['limit' => config('services.pipedrive.limit', 500)]];
 
         if (gettype($credentials) == 'object') {
             $this->isOauth = true;


### PR DESCRIPTION
response limit defaults to 500 because that is the maximum that pipedrive allows