### PR TITLE
Fixed 'Field not found' error on PersonFields

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -127,8 +127,10 @@ class Builder
     {
         $result = $this->getTarget();
 
-        if (!empty($this->getResource())) {
+        if (!empty($this->getResource()) && !empty($result)) {
             $result = $this->getResource() . '/' . $result;
+        } elseif (!empty($this->getResource())) {
+            $result = $this->getResource();
         }
 
         return $result;


### PR DESCRIPTION
Caused by changed behaviour of v1 API. Making the / return a 404 error.

Fixed this by one appending a / when there are parameters to append.