### PR TITLE
Adding 'summary' method to Deals resource

### DIFF
--- a/src/Resources/Deals.php
+++ b/src/Resources/Deals.php
@@ -13,6 +13,23 @@ class Deals extends Entity
     use ListsProducts, ListsAttachedFiles, Searches;
 
     /**
+     * 
+     * Get the deals summary
+     * 
+     * @param array $options
+     * 
+     * @return Response
+     * 
+    */
+
+    public function summary($options = [])
+    {
+
+        return $this->request->get('summary', $options);
+
+    }
+
+    /**
      * Get the deals timeline.
      *
      * @param string $start_date


### PR DESCRIPTION
I added a `summary` method to the `Deals` class, which retrieves the deals summary using the `GET /deals/summary `endpoint of the Pipedrive API. The method accepts an array of options and returns the response containing the deals summary. For more details about the endpoint, see the [API Documentation](https://developers.pipedrive.com/docs/api/v1/Deals#getDealsSummary)