### PR TITLE
Fix deprecation warning for `get_class()` in PHP 8.3

### DIFF
--- a/src/Pipedrive.php
+++ b/src/Pipedrive.php
@@ -408,7 +408,7 @@ class Pipedrive
      */
     public function __call($name, $arguments)
     {
-        if (! in_array($name, get_class_methods(get_class()))) {
+        if (! in_array($name, get_class_methods(get_class($this)))) {
             return $this->{$name};
         }
     }


### PR DESCRIPTION
This pull request addresses a deprecation warning introduced in PHP 8.3:

* The `get_class()` function should not be called without arguments. This fix ensures compatibility with PHP 8.3 and above.